### PR TITLE
vc expects vc-darcs-responsible-p to return its repo directory, not a boolean

### DIFF
--- a/vc-darcs.el
+++ b/vc-darcs.el
@@ -350,7 +350,7 @@ list of arguments to pass."
   "Return non-nil if we feel responsible for FILE,
  which can also be a directory."
   (and (not (vc-darcs-special-file-p file))
-       (not (null (vc-darcs-root file)))))
+       (vc-darcs-root file)))
 
 (defun vc-darcs-could-register (file)
   "Return non-nil if FILE could be registered."


### PR DESCRIPTION
This fixes the (unusual, I suppose) case where there is a darcs directory inside a git directory or vice-versa.

`vc-responsible-backend` finds both, then tries to sort them to figure out which is more specific. [This sort](https://github.com/emacs-mirror/emacs/blob/master/lisp/vc/vc.el#L1052) fails because `vc-darcs-repsonsible-p` returns `t`, and sort doesn't like comparing that to a string.

The vc.el file [says this](https://github.com/emacs-mirror/emacs/blob/master/lisp/vc/vc.el#L221):
```lisp
;; - responsible-p (file)
;;
;;   Return the directory if this backend considers itself "responsible" for
;;   FILE, which can also be a directory.  This function is used to find
;;   out what backend to use for registration of new files and for things
;;   like change log generation.  The default implementation always
;;   returns nil.
```